### PR TITLE
Use bash instead of sh

### DIFF
--- a/00.SetupEnv.md
+++ b/00.SetupEnv.md
@@ -42,7 +42,7 @@ Using Azure Cloud Shell and Azure Cli script you can create a lab environment fa
     > Care with subscription name when you run the script
 
     ```bash
-    sh ./azlab.azcli
+    bash ./azlab.azcli
     ```
 
     ![run script](./images/env01.01.png)


### PR DESCRIPTION
We tried using sh in the cloud shell but the substitution code only works under bash.  This changes the CLI script to use bash which completed the setup procedure successfully.  